### PR TITLE
Eks lbc acm perms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ module "comet_eks" {
   eks_cert_manager                 = var.eks_cert_manager
   eks_aws_cloudwatch_metrics       = var.eks_aws_cloudwatch_metrics
   eks_external_dns                 = var.eks_external_dns
+  eks_external_dns_r53_zones       = var.eks_external_dns_r53_zones
 
   s3_enabled              = var.enable_s3
   comet_ec2_s3_iam_policy = var.enable_s3 ? module.comet_s3[0].comet_s3_iam_policy_arn : null

--- a/modules/comet_eks/main.tf
+++ b/modules/comet_eks/main.tf
@@ -50,7 +50,7 @@ module "irsa-ebs-csi" {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "0.2.0"
+  version = "1.9.1"
 
   cluster_name      = module.eks.cluster_name
   cluster_endpoint  = module.eks.cluster_endpoint

--- a/modules/comet_eks/main.tf
+++ b/modules/comet_eks/main.tf
@@ -68,6 +68,7 @@ module "eks_blueprints_addons" {
   enable_cert_manager                 = var.eks_cert_manager
   enable_aws_cloudwatch_metrics       = var.eks_aws_cloudwatch_metrics
   enable_external_dns                 = var.eks_external_dns
+  external_dns_route53_zone_arns      = var.eks_external_dns_r53_zones
 
   tags = local.tags
 }

--- a/modules/comet_eks/variables.tf
+++ b/modules/comet_eks/variables.tf
@@ -68,6 +68,11 @@ variable "eks_external_dns" {
   type        = bool
 }
 
+variable "eks_external_dns_r53_zones" {
+  description = "Route 53 zones for external-dns to have access to"
+  type        = list(string)
+}
+
 variable "s3_enabled" {
   description = "Indicates if S3 bucket is being provisioned for Comet"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -190,7 +190,15 @@ variable "eks_aws_cloudwatch_metrics" {
 variable "eks_external_dns" {
   description = "Enables ExternalDNS in the EKS cluster"
   type        = bool
-  default     = true
+  default     = false
+}
+
+variable "eks_external_dns_r53_zones" {
+  description = "Route 53 zones for external-dns to have access to"
+  type        = list(string)
+  default     = [
+    "arn:aws:route53:::hostedzone/XYZ"
+  ]
 }
 
 #### comet_elasticache ####

--- a/variables.tf
+++ b/variables.tf
@@ -136,7 +136,7 @@ variable "eks_cluster_name" {
 variable "eks_cluster_version" {
   description = "Kubernetes version of the EKS cluster"
   type        = string
-  default     = "1.26"
+  default     = "1.27"
 }
 
 variable "eks_mng_name" {
@@ -178,7 +178,7 @@ variable "eks_aws_load_balancer_controller" {
 variable "eks_cert_manager" {
   description = "Enables cert-manager in the EKS cluster"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "eks_aws_cloudwatch_metrics" {


### PR DESCRIPTION
- fix broken permissions policy for ACM access from load balancer controller addon in EKS module
- fix config for external-dns to enable specifying r53 hosted zones and resolve permissions error which crashed the controller