### PR TITLE
DT-560 updates k8s and adds vpc cidr input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ module "comet_vpc" {
   environment = var.environment
   common_tags = local.all_tags
   region      = var.region
+  vpc_cidr    = var.vpc_cidr
 
   eks_enabled        = var.enable_eks
   single_nat_gateway = var.single_nat_gateway

--- a/modules/comet_vpc/main.tf
+++ b/modules/comet_vpc/main.tf
@@ -2,7 +2,7 @@ data "aws_availability_zones" "available" {}
 
 locals {
   resource_name = "comet-${var.environment}"
-  vpc_cidr      = "10.0.0.0/16"
+  vpc_cidr      = var.vpc_cidr
   azs           = slice(data.aws_availability_zones.available.names, 0, 3)
 }
 

--- a/modules/comet_vpc/variables.tf
+++ b/modules/comet_vpc/variables.tf
@@ -23,3 +23,9 @@ variable "region" {
   description = "AWS region to provision resources in"
   type        = string
 }
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}

--- a/statebackend.tf
+++ b/statebackend.tf
@@ -1,0 +1,10 @@
+# Uncomment to use S3 backend for remote state
+# terraform {
+#   backend "s3" {
+#     bucket         = "your-terraform-state-bucket"
+#     key            = "path/to/terraform.tfstate"
+#     region         = "us-east-1"
+#     dynamodb_table = "your-lock-table"         # Optional: for state locking
+#     encrypt        = true
+#   }
+# }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -11,7 +11,7 @@
 
 # Deployment identifier
 ## Places an Environment tag on all resources created by this module
-environment_tag = "deployment-development"
+# environment_tag = "deployment-development"
 
 ########################
 #### Module toggles ####
@@ -59,6 +59,10 @@ comet_private_subnets = ["subnet-012345abcdefghijkl", "subnet-012345abcdefghijkl
 #### Module inputs ####
 #######################
 ## Required module inputs listed below. Any desired overrides from the defaults in variables.tf can also be added here
+
+#### comet_vpc ####
+# # If setting enable_vpc, you may specify the CIDR block for the VPC below
+# vpc_cidr = "your.cidr.block/16"
 
 #### comet_ec2 ####
 #

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,13 @@ variable "comet_public_subnets" {
 #### Module inputs ####
 #######################
 
+#### comet_vpc ####
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC to provision"
+  type        = string
+  default     = "10.0.0/16"
+}
+
 #### comet_ec2 ####
 variable "comet_ec2_ami_type" {
   type        = string
@@ -147,7 +154,7 @@ variable "eks_cluster_name" {
 variable "eks_cluster_version" {
   description = "Kubernetes version of the EKS cluster"
   type        = string
-  default     = "1.27"
+  default     = "1.33"
 }
 
 variable "eks_mng_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -87,7 +87,7 @@ variable "comet_public_subnets" {
 variable "vpc_cidr" {
   description = "CIDR block for the VPC to provision"
   type        = string
-  default     = "10.0.0/16"
+  default     = "10.0.0.0/16"
 }
 
 #### comet_ec2 ####
@@ -154,7 +154,7 @@ variable "eks_cluster_name" {
 variable "eks_cluster_version" {
   description = "Kubernetes version of the EKS cluster"
   type        = string
-  default     = "1.33"
+  default     = "1.32"
 }
 
 variable "eks_mng_name" {


### PR DESCRIPTION
https://comet-ml.atlassian.net/browse/DT-560

Also added a `statebackend.tf` file that can be uncommented and filled out if desired.

Tested with both with and without declaring a vpc_cidr in the `.tfvars`.  Smoke-tested Comet in one of the deploys as well.

Should be good to merge.