### PR TITLE
Add rds_environment variable for RDS naming override

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -174,7 +174,7 @@ module "comet_elasticache" {
 module "comet_rds" {
   source      = "./modules/comet_rds"
   count       = var.enable_rds ? 1 : 0
-  environment = var.environment
+  environment = coalesce(var.rds_environment, var.environment)
   common_tags = local.all_tags
 
   availability_zones  = var.enable_vpc ? module.comet_vpc[0].azs : var.availability_zones

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "environment" {
   default     = "dev"
 }
 
+variable "rds_environment" {
+  description = "Override environment name for RDS resource naming. When null, falls back to var.environment. Use this when the environment was shortened (e.g. for ElastiCache 40-char limit) but RDS resources were originally created with a longer name."
+  type        = string
+  default     = null
+}
+
 variable "region" {
   description = "AWS region to provision resources in"
   type        = string


### PR DESCRIPTION
## Summary

When the \`environment\` variable is shortened (e.g. for ElastiCache's 40-char name limit), RDS resources that were originally created with the longer name become orphaned — Terraform plans to **destroy and recreate them** because the computed resource names no longer match.

This was discovered during a module bump (v3.11.0 → v3.14.0): \`terraform plan\` showed the production Aurora MySQL cluster being destroyed and recreated because the subnet group, parameter group, and security group names all changed due to the environment name mismatch.

## Changes

**\`variables.tf\`**: New variable:
\`\`\`hcl
variable "rds_environment" {
  description = "Override environment name for RDS resource naming. When null, falls back to var.environment."
  type        = string
  default     = null
}
\`\`\`

**\`main.tf\`**: One-line change in the RDS module call:
\`\`\`hcl
# Before
environment = var.environment

# After
environment = coalesce(var.rds_environment, var.environment)
\`\`\`

\`coalesce()\` returns the first non-null value — if \`rds_environment\` is set, use it; if null, fall back to \`environment\`. No changes inside \`modules/comet_rds/\`.

## Backward compatibility

- **Existing deployments that don't set \`rds_environment\`**: zero impact — \`coalesce(null, var.environment)\` returns \`var.environment\`, identical to current behavior
- **Deployments that need it** (shortened \`environment\`): set \`rds_environment\` to the original long name that RDS resources were created with

## Usage

\`\`\`hcl
module "comet" {
  source  = "comet-ml/comet/aws"

  environment     = "my-env"                # shortened for ElastiCache
  rds_environment = "my-env-us-east-1"      # original RDS resource naming
}
\`\`\`

## Related

- DND-955
- DND-908