### PR TITLE
Add rds_environment variable for RDS naming override

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -174,7 +174,7 @@ module "comet_elasticache" {
 module "comet_rds" {
   source      = "./modules/comet_rds"
   count       = var.enable_rds ? 1 : 0
-  environment = var.environment
+  environment = coalesce(var.rds_environment, var.environment)
   common_tags = local.all_tags
 
   availability_zones  = var.enable_vpc ? module.comet_vpc[0].azs : var.availability_zones

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "environment" {
   default     = "dev"
 }
 
+variable "rds_environment" {
+  description = "Override environment name for RDS resource naming. When null, falls back to var.environment. Use this when the environment was shortened but RDS resources were originally created with a longer name."
+  type        = string
+  default     = null
+}
+
 variable "region" {
   description = "AWS region to provision resources in"
   type        = string


### PR DESCRIPTION
## Summary

Adds an optional \`rds_environment\` variable that overrides the environment name passed to the RDS submodule. This prevents accidental destruction of RDS resources during module upgrades when the \`environment\` variable has been shortened.

## Problem

The RDS submodule names resources with \`\${var.environment}\` (subnet group, cluster, parameter group, security group). If \`environment\` was shortened at some point (e.g. for ElastiCache's 40-char name limit), upgrading the module causes Terraform to plan destruction and recreation of the RDS cluster — because the resource names no longer match.

## Changes

**\`variables.tf\`**:
\`\`\`hcl
variable "rds_environment" {
  description = "Override environment name for RDS resource naming. When null, falls back to var.environment."
  type        = string
  default     = null
}
\`\`\`

**\`main.tf\`**:
\`\`\`hcl
module "comet_rds" {
  ...
  environment = coalesce(var.rds_environment, var.environment)
}
\`\`\`

## Backward compatibility

- **Existing deployments**: zero impact — \`coalesce(null, var.environment)\` returns \`var.environment\`
- **Deployments that need it**: set \`rds_environment\` to the original name RDS resources were created with

## Usage

\`\`\`hcl
module "comet" {
  environment     = "my-env"             # shortened for ElastiCache
  rds_environment = "my-env-us-east-1"   # original RDS resource naming
}
\`\`\`

## Related

- DND-955
- DND-908