### PR TITLE
Add rds_cluster_identifier and rds_instance_identifier_prefix overrides

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,10 +172,12 @@ module "comet_elasticache" {
 }
 
 module "comet_rds" {
-  source      = "./modules/comet_rds"
-  count       = var.enable_rds ? 1 : 0
-  environment = coalesce(var.rds_environment, var.environment)
-  common_tags = local.all_tags
+  source                         = "./modules/comet_rds"
+  count                          = var.enable_rds ? 1 : 0
+  environment                    = coalesce(var.rds_environment, var.environment)
+  rds_cluster_identifier         = var.rds_cluster_identifier
+  rds_instance_identifier_prefix = var.rds_instance_identifier_prefix
+  common_tags                    = local.all_tags
 
   availability_zones  = var.enable_vpc ? module.comet_vpc[0].azs : var.availability_zones
   vpc_id              = var.enable_vpc ? module.comet_vpc[0].vpc_id : var.comet_vpc_id

--- a/modules/comet_ec2/main.tf
+++ b/modules/comet_ec2/main.tf
@@ -129,10 +129,10 @@ resource "aws_instance" "comet_ec2" {
       var.comet_ec2_ami_type == "al2" ? data.aws_ami.al2.id : (
         var.comet_ec2_ami_type == "rhel7" ? data.aws_ami.rhel7.id : (
           var.comet_ec2_ami_type == "rhel8" ? data.aws_ami.rhel8.id : (
-            var.comet_ec2_ami_type == "rhel9" ? data.aws_ami.rhel9.id : (              
+            var.comet_ec2_ami_type == "rhel9" ? data.aws_ami.rhel9.id : (
               var.comet_ec2_ami_type == "ubuntu20" ? data.aws_ami.ubuntu20.id : (
                 var.comet_ec2_ami_type == "ubuntu22" ? data.aws_ami.ubuntu22.id : (
-                  null))))))))
+  null))))))))
   instance_type          = var.comet_ec2_instance_type
   key_name               = var.comet_ec2_key
   count                  = var.comet_ec2_instance_count
@@ -154,7 +154,7 @@ resource "aws_instance" "comet_ec2" {
       Name = "${var.environment}-comet-ml-${count.index}"
     }
   )
-  
+
   lifecycle {
     create_before_destroy = true
   }

--- a/modules/comet_rds/main.tf
+++ b/modules/comet_rds/main.tf
@@ -40,7 +40,7 @@ resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
 
 resource "aws_rds_cluster_instance" "comet-ml-rds-mysql" {
   count              = var.rds_instance_count
-  identifier         = "cometml-rds-${var.environment}-${count.index}"
+  identifier         = "${coalesce(var.rds_instance_identifier_prefix, "cometml-rds-${var.environment}")}-${count.index}"
   cluster_identifier = aws_rds_cluster.cometml-db-cluster.id
   instance_class     = var.rds_instance_type
   engine             = var.rds_engine
@@ -53,7 +53,7 @@ resource "aws_rds_cluster_instance" "comet-ml-rds-mysql" {
 }
 
 resource "aws_rds_cluster" "cometml-db-cluster" {
-  cluster_identifier                  = "cometml-rds-cluster-${var.environment}"
+  cluster_identifier                  = coalesce(var.rds_cluster_identifier, "cometml-rds-cluster-${var.environment}")
   db_subnet_group_name                = aws_db_subnet_group.comet-ml-rds-subnet.name
   availability_zones                  = var.availability_zones
   database_name                       = var.rds_snapshot_identifier == null ? var.rds_database_name : null

--- a/modules/comet_rds/variables.tf
+++ b/modules/comet_rds/variables.tf
@@ -3,6 +3,18 @@ variable "environment" {
   type        = string
 }
 
+variable "rds_cluster_identifier" {
+  description = "Override for RDS cluster identifier. When null, uses default pattern 'cometml-rds-cluster-{environment}'."
+  type        = string
+  default     = null
+}
+
+variable "rds_instance_identifier_prefix" {
+  description = "Override prefix for RDS instance identifiers. When null, uses default pattern 'cometml-rds-{environment}'. Instance index is appended."
+  type        = string
+  default     = null
+}
+
 variable "availability_zones" {
   description = "List of availability zones from VPC"
   type        = list(string)
@@ -71,7 +83,7 @@ variable "rds_database_name" {
 variable "rds_master_username" {
   description = "Master username for RDS database"
   type        = string
-	default     = "admin"
+  default     = "admin"
 }
 
 variable "rds_master_password" {

--- a/modules/comet_vpc/main.tf
+++ b/modules/comet_vpc/main.tf
@@ -43,8 +43,8 @@ module "vpc" {
 }
 
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id = module.vpc.vpc_id
-  service_name = "com.amazonaws.${var.region}.s3"
+  vpc_id            = module.vpc.vpc_id
+  service_name      = "com.amazonaws.${var.region}.s3"
   vpc_endpoint_type = "Gateway"
   route_table_ids   = concat(module.vpc.private_route_table_ids, module.vpc.public_route_table_ids)
   tags = merge(

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,18 @@ variable "rds_environment" {
   default     = null
 }
 
+variable "rds_cluster_identifier" {
+  description = "Override for the RDS cluster identifier. When null, uses the default pattern. Use this when the cluster was created with a different naming convention than the current module version."
+  type        = string
+  default     = null
+}
+
+variable "rds_instance_identifier_prefix" {
+  description = "Override prefix for RDS instance identifiers. When null, uses the default pattern. Instance index is appended automatically."
+  type        = string
+  default     = null
+}
+
 variable "region" {
   description = "AWS region to provision resources in"
   type        = string


### PR DESCRIPTION
## Summary

Adds optional override variables for the RDS cluster identifier and instance identifier prefix. This prevents accidental cluster destruction during module upgrades when the RDS naming convention differs from the current module version.

Follows the same \`coalesce()\` pattern as the \`rds_environment\` variable from PR #53.

## Problem

The RDS cluster identifier pattern changed between module versions (\`cometml-rds-\` → \`cometml-rds-cluster-\`). Deployments created under older module versions have clusters with the old naming. Upgrading the module causes Terraform to plan destruction and recreation of the cluster because the identifier no longer matches.

## Changes

### Root module
- \`variables.tf\`: 2 new variables (\`rds_cluster_identifier\`, \`rds_instance_identifier_prefix\`)
- \`main.tf\`: pass both through to \`comet_rds\` submodule

### \`modules/comet_rds\`
- \`variables.tf\`: 2 new variables (default null)
- \`main.tf\`:
  - \`cluster_identifier = coalesce(var.rds_cluster_identifier, "cometml-rds-cluster-\${var.environment}")\`
  - \`identifier = "\${coalesce(var.rds_instance_identifier_prefix, "cometml-rds-\${var.environment}")}-\${count.index}"\`

### Formatting
Includes \`terraform fmt\` whitespace fixes in \`comet_ec2\` and \`comet_vpc\` (pre-existing).

## Backward compatibility

- **Existing deployments**: zero impact — \`coalesce(null, default_pattern)\` returns the default
- **Deployments that need it**: set the override to match the actual AWS resource name

## Usage

\`\`\`hcl
module "comet" {
  rds_cluster_identifier         = "cometml-rds-my-cluster-name"
  rds_instance_identifier_prefix = "cometml-rds-my-cluster-name"
}
\`\`\`

## Related

- PR #53 (rds_environment override — same pattern)
- DND-955, DND-908