### PR TITLE
feat(rds): add rds_cluster_parameters variable for custom MySQL tunings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -203,6 +203,9 @@ module "comet_rds" {
 
   # Storage type (aurora-iopt1 for I/O-Optimized)
   rds_storage_type = var.rds_storage_type
+
+  # Additional MySQL cluster parameters (defaults include operational tunings)
+  rds_cluster_parameters = var.rds_cluster_parameters
 }
 
 module "comet_s3" {

--- a/modules/comet_rds/main.tf
+++ b/modules/comet_rds/main.tf
@@ -140,6 +140,15 @@ resource "aws_rds_cluster_parameter_group" "cometml-cluster-pg" {
     name         = "log_bin_trust_function_creators"
     value        = "1"
   }
+
+  dynamic "parameter" {
+    for_each = var.rds_cluster_parameters
+    content {
+      apply_method = parameter.value.apply_method
+      name         = parameter.value.name
+      value        = parameter.value.value
+    }
+  }
 }
 
 resource "aws_security_group" "mysql_sg" {

--- a/modules/comet_rds/variables.tf
+++ b/modules/comet_rds/variables.tf
@@ -71,7 +71,7 @@ variable "rds_database_name" {
 variable "rds_master_username" {
   description = "Master username for RDS database"
   type        = string
-	default     = "admin"
+  default     = "admin"
 }
 
 variable "rds_master_password" {
@@ -119,4 +119,22 @@ variable "rds_storage_type" {
   description = "Aurora storage type. Use 'aurora-iopt1' for I/O-Optimized (eliminates I/O charges, 30% instance surcharge). Default null uses Aurora Standard."
   type        = string
   default     = null
+}
+
+variable "rds_cluster_parameters" {
+  description = "Additional MySQL parameters applied to the cluster parameter group on top of the module's baseline character-set/collation/innodb defaults. Defaults include operational tunings (wait_timeout, max_execution_time, innodb purge settings, aurora_read_replica_read_committed) used across Comet STSAAS deployments. Pass [] to disable, or override with a custom list."
+  type = list(object({
+    name         = string
+    value        = string
+    apply_method = string
+  }))
+  default = [
+    { name = "aurora_read_replica_read_committed", value = "ON", apply_method = "immediate" },
+    { name = "innodb_max_purge_lag", value = "1000000", apply_method = "immediate" },
+    { name = "innodb_max_purge_lag_delay", value = "300000", apply_method = "immediate" },
+    { name = "innodb_purge_batch_size", value = "5000", apply_method = "immediate" },
+    { name = "innodb_purge_threads", value = "16", apply_method = "pending-reboot" },
+    { name = "max_execution_time", value = "60000", apply_method = "immediate" },
+    { name = "wait_timeout", value = "1800", apply_method = "immediate" },
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -704,3 +704,21 @@ variable "rds_storage_type" {
   type        = string
   default     = null
 }
+
+variable "rds_cluster_parameters" {
+  description = "Additional MySQL parameters applied to the cluster parameter group on top of the module's baseline character-set/collation/innodb defaults. Defaults include operational tunings (wait_timeout, max_execution_time, innodb purge settings, aurora_read_replica_read_committed) used across Comet STSAAS deployments. Pass [] to disable, or override with a custom list."
+  type = list(object({
+    name         = string
+    value        = string
+    apply_method = string
+  }))
+  default = [
+    { name = "aurora_read_replica_read_committed", value = "ON", apply_method = "immediate" },
+    { name = "innodb_max_purge_lag", value = "1000000", apply_method = "immediate" },
+    { name = "innodb_max_purge_lag_delay", value = "300000", apply_method = "immediate" },
+    { name = "innodb_purge_batch_size", value = "5000", apply_method = "immediate" },
+    { name = "innodb_purge_threads", value = "16", apply_method = "pending-reboot" },
+    { name = "max_execution_time", value = "60000", apply_method = "immediate" },
+    { name = "wait_timeout", value = "1800", apply_method = "immediate" },
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a new `rds_cluster_parameters` list-of-object variable to the `comet_rds` submodule (plumbed through the root module) that lets customers extend the RDS cluster parameter group beyond the 12 baseline parameters hardcoded in `modules/comet_rds/main.tf`.

The variable ships with **seven operational tunings as defaults** — these are already applied in AWS across Comet STSAAS deployments (discovered on Zoox, confirmed by `aws rds describe-db-cluster-parameters --source user`):

| Parameter | Value | Apply Method |
|-----------|-------|--------------|
| `aurora_read_replica_read_committed` | `ON` | immediate |
| `innodb_max_purge_lag` | `1000000` | immediate |
| `innodb_max_purge_lag_delay` | `300000` | immediate |
| `innodb_purge_batch_size` | `5000` | immediate |
| `innodb_purge_threads` | `16` | pending-reboot |
| `max_execution_time` | `60000` | immediate |
| `wait_timeout` | `1800` | immediate |

## Why

These seven parameters had been set manually in AWS (likely via console or one-off ad-hoc commands) on several STSAAS clusters. Because `aws_rds_cluster_parameter_group` owns its full parameter set, every `terraform plan` on those customers was showing these seven as `-` (to be removed on next apply). That meant applying the module would revert the tunings.

Zoox surfaced this today: running `terraform plan` on `FRED/prod/us-west-2/zoox` showed the module wanting to strip the seven parameters from `cometml-rds-cluster-pg-zoox-stsaas-us-west-2`. Rather than re-applying them out of band after each run, we want them represented in code.

## How it works

- Module-level (`modules/comet_rds/main.tf`): the static 12 baseline parameters remain hardcoded. A `dynamic "parameter"` block iterates over the new variable and appends its entries to the same `aws_rds_cluster_parameter_group` resource.
- Customers get the seven defaults automatically on upgrade.
- Customers who want *different* tunings can pass their own list in tfvars — e.g. Netflix-specific knobs.
- Passing `rds_cluster_parameters = []` disables the defaults entirely (keeps only the baseline 12).

## Validated

Tested by pointing a `dply-managed-clients` zoox deployment's `module "comet"` source at this local branch and running `terraform plan`:

- **Before** (registry v3.14.0): plan showed `aws_rds_cluster_parameter_group.cometml-cluster-pg will be updated in-place` with the seven tunings being **removed**.
- **After** (this branch): plan no longer contains the parameter group in the changeset. The tunings are preserved.
- Plan overall moved from `1 to add, 9 to change, 1 to destroy` → `0 to add, 9 to change, 0 to destroy`. (The 1 destroy was an unrelated ClickHouse nodegroup issue driven by `instance_types` drift; it was fixed separately in Zoox's tfvars.)

## Backwards compatibility

On first apply after this module version ships, any STSAAS cluster that does **not** already have these seven parameters set will gain them. For the customers where we already manually applied them (e.g. Zoox), the apply will be a no-op for the parameter group. Reviewers should confirm this is safe to roll out universally — the values above look like sensible operational defaults for Comet's workload, but flag any customer where we'd want different values and we can override them in their tfvars.

No changes to resource names, parameter group name, or attachment; existing state is preserved.

## Test plan

- [ ] Review the seven default values and confirm they should ship universally
- [ ] Release a new module version (3.14.1 / 3.15.0) after merge
- [ ] Bump Zoox's `module "comet"` version to the new release and confirm plan is clean
- [ ] Run plan on at least one other STSAAS customer (bayer, netflix, fetch, etc.) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)