### PR TITLE
feat(elasticache): expose automatic_failover_enabled + multi_az_enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,13 +162,15 @@ module "comet_elasticache" {
   elasticache_allow_from_sg = var.enable_ec2 ? module.comet_ec2[0].comet_ec2_sg_id : (
     var.enable_eks ? module.comet_eks[0].nodegroup_sg_id : (
   var.elasticache_allow_from_sg))
-  elasticache_engine             = var.elasticache_engine
-  elasticache_engine_version     = var.elasticache_engine_version
-  elasticache_instance_type      = var.elasticache_instance_type
-  elasticache_param_group_name   = var.elasticache_param_group_name
-  elasticache_num_cache_nodes    = var.elasticache_num_cache_nodes
-  elasticache_transit_encryption = var.elasticache_transit_encryption
-  elasticache_auth_token         = var.elasticache_auth_token
+  elasticache_engine                     = var.elasticache_engine
+  elasticache_engine_version             = var.elasticache_engine_version
+  elasticache_instance_type              = var.elasticache_instance_type
+  elasticache_param_group_name           = var.elasticache_param_group_name
+  elasticache_num_cache_nodes            = var.elasticache_num_cache_nodes
+  elasticache_transit_encryption         = var.elasticache_transit_encryption
+  elasticache_auth_token                 = var.elasticache_auth_token
+  elasticache_automatic_failover_enabled = var.elasticache_automatic_failover_enabled
+  elasticache_multi_az_enabled           = var.elasticache_multi_az_enabled
 }
 
 module "comet_rds" {

--- a/modules/comet_elasticache/main.tf
+++ b/modules/comet_elasticache/main.tf
@@ -7,7 +7,8 @@ resource "aws_elasticache_replication_group" "comet-ml-ec-redis" {
   engine_version             = var.elasticache_engine_version
   transit_encryption_enabled = var.elasticache_transit_encryption
   auth_token                 = var.elasticache_auth_token
-  automatic_failover_enabled = false
+  automatic_failover_enabled = var.elasticache_automatic_failover_enabled
+  multi_az_enabled           = var.elasticache_multi_az_enabled
   replication_group_id       = "cometml-ec-redis-${var.environment}"
   node_type                  = var.elasticache_instance_type
   num_cache_clusters         = var.elasticache_num_cache_nodes

--- a/modules/comet_elasticache/variables.tf
+++ b/modules/comet_elasticache/variables.tf
@@ -48,6 +48,18 @@ variable "elasticache_transit_encryption" {
   type        = bool
 }
 
+variable "elasticache_automatic_failover_enabled" {
+  description = "Enable automatic failover for the ElastiCache replication group. Requires at least one replica (elasticache_num_cache_nodes >= 2)."
+  type        = bool
+  default     = false
+}
+
+variable "elasticache_multi_az_enabled" {
+  description = "Enable Multi-AZ for the ElastiCache replication group. Requires automatic_failover to also be enabled and at least one replica in a different AZ."
+  type        = bool
+  default     = false
+}
+
 variable "elasticache_auth_token" {
   description = "Auth token for ElastiCache"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -584,6 +584,18 @@ variable "elasticache_auth_token" {
   default     = null
 }
 
+variable "elasticache_automatic_failover_enabled" {
+  description = "Enable automatic failover for the ElastiCache replication group. Requires at least one replica (elasticache_num_cache_nodes >= 2)."
+  type        = bool
+  default     = false
+}
+
+variable "elasticache_multi_az_enabled" {
+  description = "Enable Multi-AZ for the ElastiCache replication group. Requires automatic_failover to also be enabled and at least one replica in a different AZ."
+  type        = bool
+  default     = false
+}
+
 #### comet_rds ####
 variable "rds_allow_from_sg" {
   description = "Security group from which to allow connections to RDS, to use when provisioning with existing compute"


### PR DESCRIPTION
## Summary
- `aws_elasticache_replication_group.comet-ml-ec-redis` previously hardcoded `automatic_failover_enabled = false` and didn't set `multi_az_enabled` at all
- This PR exposes both as variables with safe defaults (`false`), so downstream deployments can opt into HA without forking the module
- Backwards-compatible — any existing consumer that doesn't set the new variables keeps today's behavior exactly

## Why
The Zoox incident ([CUST-5800](https://comet-ml.atlassian.net/browse/CUST-5800), 2026-04-21/22) ended with Redis on a primary + cross-AZ replica with automatic failover enabled — set up via AWS CLI. Without these module variables, every future `terraform apply` on Zoox plans to disable HA and send the cluster back to single-primary-no-failover.

Once this merges and a module version is tagged, Zoox (and any future customer needing Redis HA) can pass the new variables through in their root tfvars.

## Changes

### `modules/comet_elasticache/`
| File | Change |
|---|---|
| `variables.tf` | Add `elasticache_automatic_failover_enabled` (bool, default `false`) and `elasticache_multi_az_enabled` (bool, default `false`) |
| `main.tf` | Wire both into the `aws_elasticache_replication_group` resource |

### Root module
| File | Change |
|---|---|
| `variables.tf` | Add passthrough variables with matching defaults |
| `main.tf` | Pass them through to the `comet_elasticache` module |

## Backward compatibility
`false` defaults preserve the exact behavior the module has shipped with for every prior release. Existing state files reference the same resource attributes; an `apply` on an unchanged config will be a no-op.

## Validation
- [x] `terraform fmt -check -recursive` — passes
- [x] `terraform validate` — passes
- [x] Default case (both variables unset) produces the same resource configuration as today: `automatic_failover_enabled = false`, `multi_az_enabled = false` (previously implicit via the attribute being absent)

## Consumer constraints
- `automatic_failover_enabled = true` requires `elasticache_num_cache_nodes >= 2`. AWS rejects the apply otherwise with a clear error.
- `multi_az_enabled = true` requires `automatic_failover_enabled = true`.
- Enabling either on a running cluster via `--apply-immediately` is non-disruptive online in practice (verified on Zoox cluster during CUST-5800).

## Test plan
- [x] Default case: no variables set → `automatic_failover = false`, `multi_az = false` (same as today)
- [ ] Consumer test: Zoox sets both to `true` → terraform plan shows no change against a live cluster that's already configured that way (validates the point of this PR)
- [ ] Consumer test: Zoox sets both to `false` against a cluster currently at `true` → plan shows both flipping to false (sanity check)

## Follow-up
After this merges and `v3.15.x` (or next release) is tagged, open a PR against [comet-ml/dply-managed-clients#zoox](https://github.com/comet-ml/dply-managed-clients) bumping the module version and passing `elasticache_automatic_failover_enabled = true`, `elasticache_multi_az_enabled = true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CUST-5800]: https://comet-ml.atlassian.net/browse/CUST-5800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ