### PR TITLE
feat: per-NG subnet_ids + RDS instance AZ + ElastiCache preferred AZ for single-AZ migrations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ module "comet_eks" {
   eks_admin_min_size       = var.eks_admin_min_size
   eks_admin_max_size       = var.eks_admin_max_size
   eks_admin_desired_size   = var.eks_admin_desired_size
+  eks_admin_subnet_ids     = var.eks_admin_subnet_ids
 
   # Comet Node Group
   eks_comet_name           = var.eks_comet_name
@@ -117,6 +118,7 @@ module "comet_eks" {
   eks_comet_min_size       = var.eks_comet_min_size
   eks_comet_max_size       = var.eks_comet_max_size
   eks_comet_desired_size   = var.eks_comet_desired_size
+  eks_comet_subnet_ids     = var.eks_comet_subnet_ids
 
   # Druid Node Group
   eks_druid_name           = var.eks_druid_name
@@ -143,6 +145,7 @@ module "comet_eks" {
   eks_clickhouse_volume_encrypted      = var.eks_clickhouse_volume_encrypted
   eks_clickhouse_delete_on_termination = var.eks_clickhouse_delete_on_termination
   eks_clickhouse_taints                = var.eks_clickhouse_taints
+  eks_clickhouse_subnet_ids            = var.eks_clickhouse_subnet_ids
 
   # Additional custom node groups
   additional_node_groups = var.eks_additional_node_groups
@@ -162,15 +165,16 @@ module "comet_elasticache" {
   elasticache_allow_from_sg = var.enable_ec2 ? module.comet_ec2[0].comet_ec2_sg_id : (
     var.enable_eks ? module.comet_eks[0].nodegroup_sg_id : (
   var.elasticache_allow_from_sg))
-  elasticache_engine                     = var.elasticache_engine
-  elasticache_engine_version             = var.elasticache_engine_version
-  elasticache_instance_type              = var.elasticache_instance_type
-  elasticache_param_group_name           = var.elasticache_param_group_name
-  elasticache_num_cache_nodes            = var.elasticache_num_cache_nodes
-  elasticache_transit_encryption         = var.elasticache_transit_encryption
-  elasticache_auth_token                 = var.elasticache_auth_token
-  elasticache_automatic_failover_enabled = var.elasticache_automatic_failover_enabled
-  elasticache_multi_az_enabled           = var.elasticache_multi_az_enabled
+  elasticache_engine                      = var.elasticache_engine
+  elasticache_engine_version              = var.elasticache_engine_version
+  elasticache_instance_type               = var.elasticache_instance_type
+  elasticache_param_group_name            = var.elasticache_param_group_name
+  elasticache_num_cache_nodes             = var.elasticache_num_cache_nodes
+  elasticache_transit_encryption          = var.elasticache_transit_encryption
+  elasticache_auth_token                  = var.elasticache_auth_token
+  elasticache_automatic_failover_enabled  = var.elasticache_automatic_failover_enabled
+  elasticache_multi_az_enabled            = var.elasticache_multi_az_enabled
+  elasticache_preferred_cache_cluster_azs = var.elasticache_preferred_cache_cluster_azs
 }
 
 module "comet_rds" {

--- a/modules/comet_eks/main.tf
+++ b/modules/comet_eks/main.tf
@@ -167,7 +167,9 @@ module "eks" {
         tags_propagate_at_launch     = true
         launch_template_version      = "$Latest"
         iam_role_additional_policies = local.node_group_iam_policies
-      }, var.eks_admin_ami_type != null ? { ami_type = var.eks_admin_ami_type } : {})
+        },
+        var.eks_admin_ami_type != null ? { ami_type = var.eks_admin_ami_type } : {},
+      var.eks_admin_subnet_ids != null ? { subnet_ids = var.eks_admin_subnet_ids } : {})
     } : {},
     # Comet Node Group
     var.enable_comet_node_group ? {
@@ -195,7 +197,9 @@ module "eks" {
         tags_propagate_at_launch     = true
         launch_template_version      = "$Latest"
         iam_role_additional_policies = local.node_group_iam_policies
-      }, var.eks_comet_ami_type != null ? { ami_type = var.eks_comet_ami_type } : {})
+        },
+        var.eks_comet_ami_type != null ? { ami_type = var.eks_comet_ami_type } : {},
+      var.eks_comet_subnet_ids != null ? { subnet_ids = var.eks_comet_subnet_ids } : {})
     } : {},
     # Druid Node Group
     (var.enable_druid_node_group && var.enable_mpm_infra) ? {
@@ -280,7 +284,9 @@ module "eks" {
         tags_propagate_at_launch     = true
         launch_template_version      = "$Latest"
         iam_role_additional_policies = local.node_group_iam_policies
-      }, var.eks_clickhouse_ami_type != null ? { ami_type = var.eks_clickhouse_ami_type } : {})
+        },
+        var.eks_clickhouse_ami_type != null ? { ami_type = var.eks_clickhouse_ami_type } : {},
+      var.eks_clickhouse_subnet_ids != null ? { subnet_ids = var.eks_clickhouse_subnet_ids } : {})
     } : {},
     # Additional custom node groups
     var.additional_node_groups

--- a/modules/comet_eks/variables.tf
+++ b/modules/comet_eks/variables.tf
@@ -101,6 +101,12 @@ variable "eks_admin_desired_size" {
   default     = 2
 }
 
+variable "eks_admin_subnet_ids" {
+  description = "Subnet IDs to constrain the admin node group to. Use to pin the NG to a single AZ. If null, inherits eks_private_subnets."
+  type        = list(string)
+  default     = null
+}
+
 # Comet Node Group Variables
 variable "eks_comet_name" {
   description = "Name for the comet node group"
@@ -153,6 +159,12 @@ variable "eks_comet_desired_size" {
   description = "Desired number of nodes in comet node group"
   type        = number
   default     = 3
+}
+
+variable "eks_comet_subnet_ids" {
+  description = "Subnet IDs to constrain the comet node group to. Use to pin the NG to a single AZ. If null, inherits eks_private_subnets."
+  type        = list(string)
+  default     = null
 }
 
 variable "eks_mng_disk_size" {
@@ -384,6 +396,12 @@ variable "eks_clickhouse_taints" {
     effect = string
   }))
   default = []
+}
+
+variable "eks_clickhouse_subnet_ids" {
+  description = "Subnet IDs to constrain the clickhouse node group to. Use to pin the NG to a single AZ. If null, inherits eks_private_subnets."
+  type        = list(string)
+  default     = null
 }
 
 variable "additional_node_groups" {

--- a/modules/comet_elasticache/main.tf
+++ b/modules/comet_elasticache/main.tf
@@ -3,20 +3,21 @@ locals {
 }
 
 resource "aws_elasticache_replication_group" "comet-ml-ec-redis" {
-  engine                     = var.elasticache_engine
-  engine_version             = var.elasticache_engine_version
-  transit_encryption_enabled = var.elasticache_transit_encryption
-  auth_token                 = var.elasticache_auth_token
-  automatic_failover_enabled = var.elasticache_automatic_failover_enabled
-  multi_az_enabled           = var.elasticache_multi_az_enabled
-  replication_group_id       = "cometml-ec-redis-${var.environment}"
-  node_type                  = var.elasticache_instance_type
-  num_cache_clusters         = var.elasticache_num_cache_nodes
-  parameter_group_name       = var.elasticache_param_group_name
-  port                       = local.redis_port
-  subnet_group_name          = aws_elasticache_subnet_group.comet-ml-ec-subnet-group.name
-  security_group_ids         = [aws_security_group.redis_inbound_sg.id]
-  description                = "Redis for CometML"
+  engine                      = var.elasticache_engine
+  engine_version              = var.elasticache_engine_version
+  transit_encryption_enabled  = var.elasticache_transit_encryption
+  auth_token                  = var.elasticache_auth_token
+  automatic_failover_enabled  = var.elasticache_automatic_failover_enabled
+  multi_az_enabled            = var.elasticache_multi_az_enabled
+  preferred_cache_cluster_azs = var.elasticache_preferred_cache_cluster_azs
+  replication_group_id        = "cometml-ec-redis-${var.environment}"
+  node_type                   = var.elasticache_instance_type
+  num_cache_clusters          = var.elasticache_num_cache_nodes
+  parameter_group_name        = var.elasticache_param_group_name
+  port                        = local.redis_port
+  subnet_group_name           = aws_elasticache_subnet_group.comet-ml-ec-subnet-group.name
+  security_group_ids          = [aws_security_group.redis_inbound_sg.id]
+  description                 = "Redis for CometML"
 }
 
 resource "aws_elasticache_subnet_group" "comet-ml-ec-subnet-group" {

--- a/modules/comet_elasticache/variables.tf
+++ b/modules/comet_elasticache/variables.tf
@@ -60,6 +60,12 @@ variable "elasticache_multi_az_enabled" {
   default     = false
 }
 
+variable "elasticache_preferred_cache_cluster_azs" {
+  description = "Preferred AZs for cache cluster nodes. Use to pin the replication group to a single AZ. List length must equal elasticache_num_cache_nodes when set. If null, AWS chooses from the subnet group."
+  type        = list(string)
+  default     = null
+}
+
 variable "elasticache_auth_token" {
   description = "Auth token for ElastiCache"
   type        = string

--- a/modules/comet_rds/main.tf
+++ b/modules/comet_rds/main.tf
@@ -45,6 +45,7 @@ resource "aws_rds_cluster_instance" "comet-ml-rds-mysql" {
   instance_class     = var.rds_instance_type
   engine             = var.rds_engine
   engine_version     = var.rds_engine_version
+  availability_zone  = var.rds_instance_availability_zones != null ? var.rds_instance_availability_zones[count.index] : null
 
   monitoring_interval                   = var.rds_enhanced_monitoring_interval
   monitoring_role_arn                   = local.enhanced_monitoring_enabled ? aws_iam_role.rds_enhanced_monitoring[0].arn : null

--- a/modules/comet_rds/variables.tf
+++ b/modules/comet_rds/variables.tf
@@ -55,6 +55,12 @@ variable "rds_instance_count" {
   type        = number
 }
 
+variable "rds_instance_availability_zones" {
+  description = "Per-instance AZ placement for Aurora cluster compute, indexed by count.index. Use to pin all instances to a single AZ. List length must equal rds_instance_count when set. If null, AWS chooses from the cluster's storage AZs."
+  type        = list(string)
+  default     = null
+}
+
 variable "rds_storage_encrypted" {
   description = "Enables encryption for RDS storage"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -309,6 +309,12 @@ variable "eks_admin_desired_size" {
   default     = 2
 }
 
+variable "eks_admin_subnet_ids" {
+  description = "Subnet IDs to constrain the admin node group to. Use to pin the NG to a single AZ. If null, inherits cluster-level eks_private_subnets."
+  type        = list(string)
+  default     = null
+}
+
 # Comet Node Group Variables
 variable "eks_comet_name" {
   description = "Name for the comet node group"
@@ -338,6 +344,12 @@ variable "eks_comet_desired_size" {
   description = "Desired number of nodes in comet node group"
   type        = number
   default     = 3
+}
+
+variable "eks_comet_subnet_ids" {
+  description = "Subnet IDs to constrain the comet node group to. Use to pin the NG to a single AZ. If null, inherits cluster-level eks_private_subnets."
+  type        = list(string)
+  default     = null
 }
 
 variable "eks_mng_disk_size" {
@@ -523,6 +535,12 @@ variable "eks_clickhouse_taints" {
   default = []
 }
 
+variable "eks_clickhouse_subnet_ids" {
+  description = "Subnet IDs to constrain the clickhouse node group to. Use to pin the NG to a single AZ. If null, inherits cluster-level eks_private_subnets."
+  type        = list(string)
+  default     = null
+}
+
 variable "eks_additional_node_groups" {
   description = "Additional EKS managed node groups to create beyond the predefined ones (admin, comet, druid, airflow, clickhouse)"
   type        = any
@@ -596,6 +614,12 @@ variable "elasticache_multi_az_enabled" {
   default     = false
 }
 
+variable "elasticache_preferred_cache_cluster_azs" {
+  description = "Preferred AZs for ElastiCache cache cluster nodes. Use to pin the replication group to a single AZ. List length must equal elasticache_num_cache_nodes when set. If null, AWS chooses from the subnet group."
+  type        = list(string)
+  default     = null
+}
+
 #### comet_rds ####
 variable "rds_allow_from_sg" {
   description = "Security group from which to allow connections to RDS, to use when provisioning with existing compute"
@@ -625,6 +649,12 @@ variable "rds_instance_count" {
   description = "Number of RDS instances in the database cluster"
   type        = number
   default     = 2
+}
+
+variable "rds_instance_availability_zones" {
+  description = "Per-instance AZ placement for Aurora cluster compute instances, indexed by instance count.index. Use to pin all instances to a single AZ. List length must equal rds_instance_count when set. If null, AWS chooses from the cluster's storage AZs."
+  type        = list(string)
+  default     = null
 }
 
 variable "rds_storage_encrypted" {


### PR DESCRIPTION
## Summary

Adds three sets of variables to support pinning module-managed resources to specific AZs, enabling single-AZ migrations under DND-908.

- **`eks_{admin,comet,clickhouse}_subnet_ids`** — per-NG subnet override; conditionally merged so when null the NG inherits the cluster-level `eks_private_subnets`.
- **`rds_instance_availability_zones`** — list-of-string, indexed by Aurora cluster instance `count.index`. Wires to `aws_rds_cluster_instance.availability_zone`.
- **`elasticache_preferred_cache_cluster_azs`** — list-of-string for the replication group's preferred AZs. Wires to `aws_elasticache_replication_group.preferred_cache_cluster_azs`.

All three variables default to `null`; existing customers see zero behavior change.

## Motivation

Today, customer single-AZ migrations (BMW DND-937 being the active case) require AWS-CLI-out-of-band operations because the module doesn't express per-resource AZ placement. With these variables, post-migration TF state can be reconciled (no plan drift) and future single-AZ-from-day-one provisioning works directly via the module.

Reference incident pattern this unblocks: see `feedback_chi_patch_must_include_full_clusters_block.md` and `project_fleet_singleaz_target_az_rule.md` — for single-replica CH customers (e.g., BMW) the right move is to migrate the data plane to the CH AZ rather than the inverse, which means we need TF-managed RDS + ElastiCache AZ pinning.

## What changed

- Root `variables.tf`: 5 new variables, all `null`-defaulted
- Root `main.tf`: pass-throughs to submodules
- `modules/comet_eks/{variables,main}.tf`: new subnet_ids vars and conditional merges into the admin / comet / clickhouse NG blocks
- `modules/comet_rds/{variables,main}.tf`: new `rds_instance_availability_zones` var, wires to `aws_rds_cluster_instance.availability_zone`
- `modules/comet_elasticache/{variables,main}.tf`: new `elasticache_preferred_cache_cluster_azs` var, wires to `aws_elasticache_replication_group.preferred_cache_cluster_azs`

`terraform fmt -recursive` + `terraform validate` both clean.

## Test plan

- [ ] Tag (e.g., v3.16.0) and bump on a single customer with `*_subnet_ids` set to a single-AZ subnet to confirm NG rolls correctly
- [ ] Confirm a customer with the new vars _unset_ sees no plan change (backward compat)
- [ ] BMW DND-937: after merge + tag, set `rds_instance_availability_zones = ["eu-central-1a", "eu-central-1a"]` + `elasticache_preferred_cache_cluster_azs = ["eu-central-1a"]` + `eks_admin_subnet_ids = ["subnet-0ca413920d4ba5bba"]` to reconcile state with the in-progress AZ migration

## Caveats

- `aws_rds_cluster_instance.availability_zone` is **ForceReplace** in the AWS provider — flipping this on an existing instance triggers destroy+create. Plan accordingly (use `create_before_destroy` or out-of-band sequencing for live clusters).
- `aws_elasticache_replication_group.preferred_cache_cluster_azs` change on an existing single-node cluster typically requires the add-replica → failover → drop-replica dance (out-of-band). The variable supports green-field deployments and post-migration TF reconciliation; mid-life AZ changes still need careful orchestration outside TF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)