### PR TITLE
feat(rds): expose max_allowed_packet as rds_max_allowed_packet variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -214,6 +214,9 @@ module "comet_rds" {
 
   # Additional MySQL cluster parameters (defaults include operational tunings)
   rds_cluster_parameters = var.rds_cluster_parameters
+
+  # Override for max_allowed_packet hardcoded baseline (per-customer query workload)
+  rds_max_allowed_packet = var.rds_max_allowed_packet
 }
 
 module "comet_s3" {

--- a/modules/comet_rds/main.tf
+++ b/modules/comet_rds/main.tf
@@ -124,7 +124,7 @@ resource "aws_rds_cluster_parameter_group" "cometml-cluster-pg" {
   parameter {
     apply_method = "pending-reboot"
     name         = "max_allowed_packet"
-    value        = "157286400"
+    value        = var.rds_max_allowed_packet
   }
   parameter {
     apply_method = "pending-reboot"

--- a/modules/comet_rds/variables.tf
+++ b/modules/comet_rds/variables.tf
@@ -139,6 +139,12 @@ variable "rds_storage_type" {
   default     = null
 }
 
+variable "rds_max_allowed_packet" {
+  description = "Cluster parameter group max_allowed_packet value (in bytes). Default 157286400 (150 MiB) matches the module's historical hardcoded value."
+  type        = string
+  default     = "157286400"
+}
+
 variable "rds_cluster_parameters" {
   description = "Additional MySQL parameters applied to the cluster parameter group on top of the module's baseline character-set/collation/innodb defaults. Defaults include operational tunings (wait_timeout, max_execution_time, innodb purge settings, aurora_read_replica_read_committed) used across Comet STSAAS deployments. Pass [] to disable, or override with a custom list."
   type = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -657,6 +657,12 @@ variable "rds_instance_availability_zones" {
   default     = null
 }
 
+variable "rds_max_allowed_packet" {
+  description = "Overrides the cluster parameter group's max_allowed_packet value (in bytes). Default 157286400 (150 MiB) matches the module's historical hardcoded value. Increase for customers running queries with large blob/JSON payloads or oversized prepared statements."
+  type        = string
+  default     = "157286400"
+}
+
 variable "rds_storage_encrypted" {
   description = "Enables encryption for RDS storage"
   type        = bool


### PR DESCRIPTION
## Summary

Parameterizes the previously hardcoded `max_allowed_packet` value (157286400 bytes / 150 MiB) on the cluster parameter group. Default preserves the historical value so existing customers see zero change.

Customers running queries with large blob/JSON payloads or oversized prepared statements can override per-environment.

## Motivation

BMW (DND-937) has a manually-created parameter group in production with `max_allowed_packet = 268435456` (256 MiB). When we bump BMW from `comet-ml/comet/aws` v3.6.1 to a current version, the module will create its own parameter group and switch the cluster to use it — which would silently downgrade the limit to 150 MiB. That breaks any query relying on >150 MiB packets.

The other 5 custom params BMW has (max_heap_table_size, temptable_*, tmp_table_size, max_execution_time) can flow through the existing `rds_cluster_parameters` variable (Daren's PR #55). Only `max_allowed_packet` is hardcoded in the resource and would conflict with a duplicate via the dynamic block — hence this separate variable.

## Changes

- Root `variables.tf`: new `rds_max_allowed_packet` (string, default `"157286400"`)
- Root `main.tf`: pass through to `comet_rds` module
- `modules/comet_rds/variables.tf`: matching submodule variable
- `modules/comet_rds/main.tf`: replace hardcoded `value = "157286400"` with `value = var.rds_max_allowed_packet`

`terraform fmt` + `terraform validate` clean.

## Test plan

- [ ] BMW's `terraform plan` (pointing at this branch ref) shows the cluster parameter group will be created with `max_allowed_packet = 268435456` when BMW sets the variable
- [ ] Default behavior verified: an environment NOT setting the variable shows no diff
- [ ] After BMW validates, tag (next release will be `v3.16.0` combining this + PR #57's per-NG subnet_ids / RDS instance AZ / ElastiCache preferred AZ vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)