### PR TITLE
feat(rds): expose collation_server + collation_connection as variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -217,6 +217,10 @@ module "comet_rds" {
 
   # Override for max_allowed_packet hardcoded baseline (per-customer query workload)
   rds_max_allowed_packet = var.rds_max_allowed_packet
+
+  # Override for collation hardcoded baselines (preserve Aurora 8.0 default for existing clusters)
+  rds_collation_server     = var.rds_collation_server
+  rds_collation_connection = var.rds_collation_connection
 }
 
 module "comet_s3" {

--- a/modules/comet_rds/main.tf
+++ b/modules/comet_rds/main.tf
@@ -104,12 +104,12 @@ resource "aws_rds_cluster_parameter_group" "cometml-cluster-pg" {
   parameter {
     apply_method = "pending-reboot"
     name         = "collation_connection"
-    value        = "utf8mb4_unicode_ci"
+    value        = var.rds_collation_connection
   }
   parameter {
     apply_method = "pending-reboot"
     name         = "collation_server"
-    value        = "utf8mb4_unicode_ci"
+    value        = var.rds_collation_server
   }
   parameter {
     apply_method = "pending-reboot"

--- a/modules/comet_rds/variables.tf
+++ b/modules/comet_rds/variables.tf
@@ -145,6 +145,18 @@ variable "rds_max_allowed_packet" {
   default     = "157286400"
 }
 
+variable "rds_collation_server" {
+  description = "Cluster parameter group collation_server value. Default 'utf8mb4_unicode_ci' matches the module's historical hardcoded value. Aurora MySQL 8.0's engine default is 'utf8mb4_0900_ai_ci' (newer Unicode standard); override to match engine default if migrating an existing cluster to avoid drift on next reboot."
+  type        = string
+  default     = "utf8mb4_unicode_ci"
+}
+
+variable "rds_collation_connection" {
+  description = "Cluster parameter group collation_connection value. Default 'utf8mb4_unicode_ci' matches the module's historical hardcoded value. See rds_collation_server for Aurora MySQL 8.0 considerations."
+  type        = string
+  default     = "utf8mb4_unicode_ci"
+}
+
 variable "rds_cluster_parameters" {
   description = "Additional MySQL parameters applied to the cluster parameter group on top of the module's baseline character-set/collation/innodb defaults. Defaults include operational tunings (wait_timeout, max_execution_time, innodb purge settings, aurora_read_replica_read_committed) used across Comet STSAAS deployments. Pass [] to disable, or override with a custom list."
   type = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -663,6 +663,18 @@ variable "rds_max_allowed_packet" {
   default     = "157286400"
 }
 
+variable "rds_collation_server" {
+  description = "Overrides the cluster parameter group's collation_server value. Default 'utf8mb4_unicode_ci' matches the module's historical hardcoded value (MySQL 5.x standard). Aurora MySQL 8.0's engine default is 'utf8mb4_0900_ai_ci'; override to match engine default to avoid drift on existing clusters."
+  type        = string
+  default     = "utf8mb4_unicode_ci"
+}
+
+variable "rds_collation_connection" {
+  description = "Overrides the cluster parameter group's collation_connection value. Default 'utf8mb4_unicode_ci' matches the module's historical hardcoded value. See rds_collation_server for Aurora MySQL 8.0 considerations."
+  type        = string
+  default     = "utf8mb4_unicode_ci"
+}
+
 variable "rds_storage_encrypted" {
   description = "Enables encryption for RDS storage"
   type        = bool


### PR DESCRIPTION
## Summary

Parameterizes the previously-hardcoded `collation_server` and `collation_connection` values on the cluster parameter group. Defaults preserve the historical hardcoded `utf8mb4_unicode_ci`, so existing customers see zero change.

## Motivation

BMW (DND-937) is bumping from v3.6.1 to v3.16.0. The manual PG in production has `collation_server` at engine-default (no explicit value), so Aurora MySQL 8.0.mysql_aurora.3.10.3 uses its built-in default `utf8mb4_0900_ai_ci` (the modern Unicode standard introduced in MySQL 8.0).

The module's hardcoded `utf8mb4_unicode_ci` is the MySQL 5.x-era standard. After the PG switch, new tables on BMW would default to the older collation — a subtle but real divergence from existing tables on the same cluster.

This PR lets BMW override the collation values to keep the engine default and avoid post-reboot drift.

## Changes

- Root `variables.tf`: 2 new variables (`rds_collation_server`, `rds_collation_connection`), defaults preserve hardcoded `utf8mb4_unicode_ci`
- Root `main.tf`: pass-through to `comet_rds` module
- `modules/comet_rds/variables.tf`: matching submodule variables
- `modules/comet_rds/main.tf`: replace hardcoded values with `var.rds_collation_*`

`terraform fmt` + `terraform validate` clean. Zero default-behavior change.

## Test plan

- [ ] Existing customer (any on `utf8mb4_unicode_ci` already) sees no plan diff after bump
- [ ] BMW with override `rds_collation_server = "utf8mb4_0900_ai_ci"` produces no PG diff vs the engine default on next plan
- [ ] After merge, tag as `v3.16.1` and bump BMW

🤖 Generated with [Claude Code](https://claude.com/claude-code)